### PR TITLE
Update for Ubuntu 20.04 + small tweeks (snap, bridged network)

### DIFF
--- a/basy-bootstrap
+++ b/basy-bootstrap
@@ -74,6 +74,8 @@ lvcreate -m1 -L8G -n "${BASY_LV}" "${BASY_VG}"
 
 ### BTRFS Filesystem anlegen und mounten
 wipefs -a "/dev/${BASY_VG}/${BASY_LV}"
+# overwrite first 10MBs with Zeros to be sure everything is gone
+dd if=/dev/zero of="/dev/${BASY_VG}/${BASY_LV}" bs=1M count=10
 mkfs.btrfs -f "/dev/${BASY_VG}/${BASY_LV}"
 
 mount "/dev/${BASY_VG}/${BASY_LV}" /mnt/
@@ -85,7 +87,7 @@ btrfs subvolume create /mnt/@snapshot
 ### Ubuntu Basissystem installieren
 apt update
 apt install -y debootstrap
-debootstrap --arch amd64 bionic /mnt/@
+debootstrap --arch amd64 focal /mnt/@
 
 btrfs subvolume snapshot /mnt/@ /mnt/@snapshot/@-`date -u +%Y%m%d%H%M%S`-basy-bootstrap
 umount /mnt

--- a/basy-setup
+++ b/basy-setup
@@ -63,19 +63,18 @@ EOT
 
 ## APT konfigurieren
 cat <<EOT > /etc/apt/sources.list
-deb http://archive.ubuntu.com/ubuntu bionic main
-deb-src http://archive.ubuntu.com/ubuntu bionic main
-deb http://archive.ubuntu.com/ubuntu bionic-updates main
-deb-src http://archive.ubuntu.com/ubuntu bionic-updates main
-deb http://security.ubuntu.com/ubuntu bionic-security main
-deb-src http://security.ubuntu.com/ubuntu bionic-security main
+deb http://de.archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
+deb http://de.archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+deb http://de.archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+deb http://de.archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
 
-deb http://archive.ubuntu.com/ubuntu bionic universe
-deb-src http://archive.ubuntu.com/ubuntu bionic universe
-deb http://archive.ubuntu.com/ubuntu bionic-updates universe
-deb-src http://archive.ubuntu.com/ubuntu bionic-updates universe
-deb http://security.ubuntu.com/ubuntu bionic-security universe
-deb-src http://security.ubuntu.com/ubuntu bionic-security universe
+deb-src http://de.archive.ubuntu.com/ubuntu/ focal main restricted universe multiverse
+deb-src http://de.archive.ubuntu.com/ubuntu/ focal-updates main restricted universe multiverse
+deb-src http://de.archive.ubuntu.com/ubuntu/ focal-security main restricted universe multiverse
+deb-src http://de.archive.ubuntu.com/ubuntu/ focal-backports main restricted universe multiverse
+
+deb http://archive.canonical.com/ubuntu focal partner
+deb-src http://archive.canonical.com/ubuntu focal partner
 EOT
 
 ## System aktualisieren
@@ -120,10 +119,9 @@ EOT
 ## tools installieren
 apt install -y htop lvm2 nano tmux iotop rsync btrfs-progs
 
-
 ## Kernel und Grub einrichten
 debconf-set-selections <<EOT
-grub-pc  grub2/linux_cmdline_default  string
+grub-pc  grub2/linux_cmdline_default  string  nomodeset
 grub-pc  grub-pc/install_devices      multiselect  ${BASY_DISK1ID}, ${BASY_DISK2ID}
 EOT
 
@@ -132,6 +130,11 @@ DEBIAN_FRONTEND=noninteractive apt install -y linux-image-generic
 echo raid1 >> /etc/initramfs-tools/modules
 update-initramfs -u
 
+for BASY_DISK in ${BASY_DISK1} ${BASY_DISK2}
+do
+  grub-install  ${BASY_DISK}
+done
+update-grub
 
 ## Passwort setzen
 passwd

--- a/lxdh-setup
+++ b/lxdh-setup
@@ -167,7 +167,7 @@ profiles:
   devices:
     eth0:
       name: eth0
-      nictype: bridge
+      nictype: bridged
       parent: lxdbr0
       type: nic
     root:

--- a/lxdh-setup
+++ b/lxdh-setup
@@ -73,7 +73,6 @@ then
   exit 1
 fi
 
-
 ### Eventuell bestehendes Logical Volume entfernen
 if [ -e "/dev/${LXDH_VG}/${LXDH_LV}" ]; then
   wipefs -a "/dev/${LXDH_VG}/${LXDH_LV}"
@@ -107,11 +106,14 @@ mkfs.btrfs -f "/dev/${LXDH_VG}/${LXDH_LV}"
 mount "/dev/${LXDH_VG}/${LXDH_LV}" /mnt/
 btrfs subvolume create /mnt/@lxd
 
-mkdir /var/lib/lxd
-mount /dev/${LXDH_VG}/${LXDH_LV} /var/lib/lxd -o subvol=@lxd
+mkdir -p /var/snap/lxd
+mount /dev/${LXDH_VG}/${LXDH_LV} /var/snap/lxd -o subvol=@lxd
+
+#mkdir -p /var/lib/lxd
+#mount /dev/${LXDH_VG}/${LXDH_LV} /var/lib/lxd -o subvol=@lxd
 
 cat <<EOT >> /etc/fstab
-/dev/${LXDH_VG}/${LXDH_LV}  /var/lib/lxd  btrfs  defaults,subvol=@lxd  0  1
+/dev/${LXDH_VG}/${LXDH_LV}  /var/snap/lxd  btrfs  defaults,subvol=@lxd  0  1
 EOT
 
 
@@ -165,7 +167,7 @@ profiles:
   devices:
     eth0:
       name: eth0
-      nictype: macvlan
+      nictype: bridge
       parent: lxdbr0
       type: nic
     root:


### PR DESCRIPTION
basy-bootstrap:
     - overwrite first 10MBs of each device to make sure that everything is gone
     - bootstrap 'focal' instead of 'bionic'
basy-setup:
     - changed apt sources to 'focal' instead of 'bionic'
     - added Grub linux command line default to 'nomodset' instead of an empty string for hardware compatibility
     - call:
       - 'grub-install' on each device
       - 'update-grub' after the 'grub-install' calls
       using 'install -y linux-image-generic' does not seem to be enough on 20.04 anymore
lxdh-setup:
       - using lxd from snap (apt only has serves lxd version)
       - adjusted lxd paths
       - adjusted container network device type from macvlan to bridged
